### PR TITLE
Update system System_Settings.json to V7 formatting

### DIFF
--- a/system_settings/System_Settings.json
+++ b/system_settings/System_Settings.json
@@ -2,151 +2,274 @@
     "business_data": {
         "resources": [
             {
+                "resourceinstance": {
+                    "descriptors": null,
+                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c",
+                    "graph_publication_id": "f0a0bf6a-65af-46f2-9c08-62e21a56dffb",
+                    "legacyid": "a106c400-260c-11e7-a604-14109fd34195",
+                    "name": "",
+                    "resourceinstanceid": "a106c400-260c-11e7-a604-14109fd34195",
+                    "publication_id": "8ad4c7f0-110f-11ee-a655-00155d3ff959"
+                },
                 "tiles": [
                     {
                         "data": {},
-                        "parenttile_id": null,
                         "nodegroup_id": "0e8ff31c-4148-11e7-998a-c4b301baab9f",
-                        "sortorder": 0,
+                        "parenttile_id": null,
+                        "provisionaledits": null,
                         "resourceinstance_id": "a106c400-260c-11e7-a604-14109fd34195",
+                        "sortorder": 0,
                         "tileid": "3442b7e7-9bee-4c54-8d37-eca3a236ef8f"
-                    },
-                    {
-                        "data": {
-                            "d0987880-fad8-11e6-8cce-6c4008b05c4c": null,
-                            "d0987de3-fad8-11e6-a434-6c4008b05c4c": 5.0,
-                            "d0987ec0-fad8-11e6-aad3-6c4008b05c4c": 100000.0,
-                            "d0987cc2-fad8-11e6-8581-6c4008b05c4c": 100.0
-                        },
-                        "parenttile_id": null,
-                        "nodegroup_id": "d0987880-fad8-11e6-8cce-6c4008b05c4c",
-                        "sortorder": 0,
-                        "resourceinstance_id": "a106c400-260c-11e7-a604-14109fd34195",
-                        "tileid": "a4e0f0e2-9840-4ba6-acae-a6c430daf917"
-                    },
-                    {
-                        "data": {},
-                        "parenttile_id": null,
-                        "nodegroup_id": "c5a2a914-fadd-11e6-8f8f-6c4008b05c4c",
-                        "sortorder": 0,
-                        "resourceinstance_id": "a106c400-260c-11e7-a604-14109fd34195",
-                        "tileid": "a70b6016-5145-4513-a6be-5901944347b4"
-                    },
-                    {
-                        "data": {
-                            "c5a2b530-fadd-11e6-b5f6-6c4008b05c4c": null,
-                            "c5a2ba63-fadd-11e6-9306-6c4008b05c4c": "arches.app.utils.data_management.sparql_providers.aat_provider.AAT_Provider"
-                        },
-                        "parenttile_id": "a70b6016-5145-4513-a6be-5901944347b4",
-                        "nodegroup_id": "c5a2b530-fadd-11e6-b5f6-6c4008b05c4c",
-                        "sortorder": 0,
-                        "resourceinstance_id": "a106c400-260c-11e7-a604-14109fd34195",
-                        "tileid": "c45a7069-1803-4d85-a017-61296a2ae760"
-                    },
-                    {
-                        "data": {
-                            "0e8ffaf5-4148-11e7-b24d-c4b301baab9f": 12,
-                            "0e8ffcab-4148-11e7-a571-c4b301baab9f": 0.25
-                        },
-                        "parenttile_id": "3442b7e7-9bee-4c54-8d37-eca3a236ef8f",
-                        "nodegroup_id": "0e8ff675-4148-11e7-9c88-c4b301baab9f",
-                        "sortorder": 0,
-                        "resourceinstance_id": "a106c400-260c-11e7-a604-14109fd34195",
-                        "tileid": "02dd0153-faa4-4016-9207-903cc87a9b73"
-                    },
-                    {
-                        "data": {
-                            "0e8fff21-4148-11e7-ba78-c4b301baab9f": 20,
-                            "0e8ff9d1-4148-11e7-90ed-c4b301baab9f": 10,
-                            "0e90017a-4148-11e7-82ce-c4b301baab9f": 4
-                        },
-                        "parenttile_id": "3442b7e7-9bee-4c54-8d37-eca3a236ef8f",
-                        "nodegroup_id": "0e8fe87a-4148-11e7-aa8b-c4b301baab9f",
-                        "sortorder": 0,
-                        "resourceinstance_id": "a106c400-260c-11e7-a604-14109fd34195",
-                        "tileid": "2e49911e-6bcf-4711-bc59-2264cb71c4ab"
-                    },
-                    {
-                        "data": {
-                            "c5a2b94a-fadd-11e6-a029-6c4008b05c4c": "Lincoln",
-                            "c5a2bdb3-fadd-11e6-8c96-6c4008b05c4c": "ETL",
-                            "c5a2b1dc-fadd-11e6-a726-6c4008b05c4c": null
-                        },
-                        "parenttile_id": "a70b6016-5145-4513-a6be-5901944347b4",
-                        "nodegroup_id": "c5a2b1dc-fadd-11e6-a726-6c4008b05c4c",
-                        "sortorder": 0,
-                        "resourceinstance_id": "a106c400-260c-11e7-a604-14109fd34195",
-                        "tileid": "4345f530-aa90-48cf-b4b3-92d1185ca439"
-                    },
-                    {
-                        "data": {
-                            "0e9000b0-4148-11e7-bd19-c4b301baab9f": "", 
-                            "0e900254-4148-11e7-9902-c4b301baab9f": "mapbox://sprites/mapbox/basic-v9",
-                            "0e90031e-4148-11e7-a176-c4b301baab9f": "mapbox://fonts/mapbox/{fontstack}/{range}.pbf"
-                        },
-                        "parenttile_id": "3442b7e7-9bee-4c54-8d37-eca3a236ef8f",
-                        "nodegroup_id": "0e8fe457-4148-11e7-9c10-c4b301baab9f",
-                        "sortorder": 0,
-                        "resourceinstance_id": "a106c400-260c-11e7-a604-14109fd34195",
-                        "tileid": "f49e37b3-3686-4fbd-98c9-ab8241f72a60"
                     },
                     {
                         "data": {
                             "0e8fdef0-4148-11e7-8330-c4b301baab9f": null,
                             "0e8ffbcf-4148-11e7-a95a-c4b301baab9f": {
-                                "type": "FeatureCollection",
                                 "features": [
                                     {
                                         "geometry": {
-                                            "type": "Polygon",
                                             "coordinates": [
                                                 [
                                                     [
-                                                        -0.5408392636652195,
-                                                        53.07348525417471
+                                                        -122,
+                                                        -52
                                                     ],
                                                     [
-                                                        -0.32083160459160354,
-                                                        53.07586109421868
+                                                        128,
+                                                        -52
                                                     ],
                                                     [
-                                                        -0.31798323455765853,
-                                                        53.3342825400086
+                                                        128,
+                                                        69
                                                     ],
                                                     [
-                                                        -0.7672423564987128,
-                                                        53.334392674726075
+                                                        -122,
+                                                        69
                                                     ],
                                                     [
-                                                        -0.7834770424313717,
-                                                        53.074059031647224
-                                                    ],
-                                                    [
-                                                        -0.5408392636652195,
-                                                        53.07348525417471
+                                                        -122,
+                                                        -52
                                                     ]
                                                 ]
-                                            ]
+                                            ],
+                                            "type": "Polygon"
                                         },
-                                        "type": "Feature",
                                         "id": "b3496f23d0e20fe8fedd646dad1cb723",
-                                        "properties": {}
+                                        "properties": {},
+                                        "type": "Feature"
                                     }
-                                ]
+                                ],
+                                "type": "FeatureCollection"
                             }
                         },
-                        "parenttile_id": "3442b7e7-9bee-4c54-8d37-eca3a236ef8f",
                         "nodegroup_id": "0e8fdef0-4148-11e7-8330-c4b301baab9f",
-                        "sortorder": 0,
+                        "parenttile_id": "3442b7e7-9bee-4c54-8d37-eca3a236ef8f",
+                        "provisionaledits": null,
                         "resourceinstance_id": "a106c400-260c-11e7-a604-14109fd34195",
+                        "sortorder": 0,
                         "tileid": "0621c870-5802-4cf0-8964-1934bd7f98bd"
+                    },
+                    {
+                        "data": {
+                            "0e8ffaf5-4148-11e7-b24d-c4b301baab9f": 4,
+                            "0e8ffcab-4148-11e7-a571-c4b301baab9f": 100
+                        },
+                        "nodegroup_id": "0e8ff675-4148-11e7-9c88-c4b301baab9f",
+                        "parenttile_id": "3442b7e7-9bee-4c54-8d37-eca3a236ef8f",
+                        "provisionaledits": null,
+                        "resourceinstance_id": "a106c400-260c-11e7-a604-14109fd34195",
+                        "sortorder": 0,
+                        "tileid": "02dd0153-faa4-4016-9207-903cc87a9b73"
+                    },
+                    {
+                        "data": {
+                            "0e8ff9d1-4148-11e7-90ed-c4b301baab9f": 0,
+                            "0e8fff21-4148-11e7-ba78-c4b301baab9f": 20,
+                            "0e90017a-4148-11e7-82ce-c4b301baab9f": 0
+                        },
+                        "nodegroup_id": "0e8fe87a-4148-11e7-aa8b-c4b301baab9f",
+                        "parenttile_id": "3442b7e7-9bee-4c54-8d37-eca3a236ef8f",
+                        "provisionaledits": null,
+                        "resourceinstance_id": "a106c400-260c-11e7-a604-14109fd34195",
+                        "sortorder": 0,
+                        "tileid": "2e49911e-6bcf-4711-bc59-2264cb71c4ab"
+                    },
+                    {
+                        "data": {
+                            "d0987880-fad8-11e6-8cce-6c4008b05c4c": null,
+                            "d0987cc2-fad8-11e6-8581-6c4008b05c4c": 100.0,
+                            "d0987de3-fad8-11e6-a434-6c4008b05c4c": 5.0,
+                            "d0987ec0-fad8-11e6-aad3-6c4008b05c4c": 10000
+                        },
+                        "nodegroup_id": "d0987880-fad8-11e6-8cce-6c4008b05c4c",
+                        "parenttile_id": null,
+                        "provisionaledits": null,
+                        "resourceinstance_id": "a106c400-260c-11e7-a604-14109fd34195",
+                        "sortorder": 0,
+                        "tileid": "a4e0f0e2-9840-4ba6-acae-a6c430daf917"
+                    },
+                    {
+                        "data": {},
+                        "nodegroup_id": "c5a2a914-fadd-11e6-8f8f-6c4008b05c4c",
+                        "parenttile_id": null,
+                        "provisionaledits": null,
+                        "resourceinstance_id": "a106c400-260c-11e7-a604-14109fd34195",
+                        "sortorder": 0,
+                        "tileid": "a70b6016-5145-4513-a6be-5901944347b4"
+                    },
+                    {
+                        "data": {
+                            "c5a2b1dc-fadd-11e6-a726-6c4008b05c4c": null,
+                            "c5a2b94a-fadd-11e6-a029-6c4008b05c4c": {
+                                "en": {
+                                    "direction": "ltr",
+                                    "value": "Arches"
+                                }
+                            },
+                            "c5a2bdb3-fadd-11e6-8c96-6c4008b05c4c": {
+                                "en": {
+                                    "direction": "ltr",
+                                    "value": "ETL"
+                                }
+                            }
+                        },
+                        "nodegroup_id": "c5a2b1dc-fadd-11e6-a726-6c4008b05c4c",
+                        "parenttile_id": "a70b6016-5145-4513-a6be-5901944347b4",
+                        "provisionaledits": null,
+                        "resourceinstance_id": "a106c400-260c-11e7-a604-14109fd34195",
+                        "sortorder": 0,
+                        "tileid": "4345f530-aa90-48cf-b4b3-92d1185ca439"
+                    },
+                    {
+                        "data": {
+                            "c5a2b530-fadd-11e6-b5f6-6c4008b05c4c": null,
+                            "c5a2ba63-fadd-11e6-9306-6c4008b05c4c": {
+                                "en": {
+                                    "direction": "ltr",
+                                    "value": "arches.app.utils.data_management.sparql_providers.aat_provider.AAT_Provider"
+                                }
+                            }
+                        },
+                        "nodegroup_id": "c5a2b530-fadd-11e6-b5f6-6c4008b05c4c",
+                        "parenttile_id": "a70b6016-5145-4513-a6be-5901944347b4",
+                        "provisionaledits": null,
+                        "resourceinstance_id": "a106c400-260c-11e7-a604-14109fd34195",
+                        "sortorder": 0,
+                        "tileid": "c45a7069-1803-4d85-a017-61296a2ae760"
+                    },
+                    {
+                        "data": {
+                            "0e9000b0-4148-11e7-bd19-c4b301baab9f": {
+                                "de": {
+                                    "direction": "ltr",
+                                    "value": ""
+                                },
+                                "el": {
+                                    "direction": "ltr",
+                                    "value": ""
+                                },
+                                "en": {
+                                    "direction": "ltr",
+                                    "value": ""
+                                },
+                                "en-US": {
+                                    "direction": "ltr",
+                                    "value": ""
+                                },
+                                "fr": {
+                                    "direction": "ltr",
+                                    "value": ""
+                                },
+                                "pt": {
+                                    "direction": "ltr",
+                                    "value": ""
+                                },
+                                "ru": {
+                                    "direction": "ltr",
+                                    "value": ""
+                                },
+                                "zh": {
+                                    "direction": "ltr",
+                                    "value": ""
+                                }
+                            },
+                            "0e900254-4148-11e7-9902-c4b301baab9f": {
+                                "de": {
+                                    "direction": "ltr",
+                                    "value": ""
+                                },
+                                "el": {
+                                    "direction": "ltr",
+                                    "value": ""
+                                },
+                                "en": {
+                                    "direction": "ltr",
+                                    "value": "mapbox://sprites/mapbox/basic-v9"
+                                },
+                                "en-US": {
+                                    "direction": "ltr",
+                                    "value": ""
+                                },
+                                "fr": {
+                                    "direction": "ltr",
+                                    "value": ""
+                                },
+                                "pt": {
+                                    "direction": "ltr",
+                                    "value": ""
+                                },
+                                "ru": {
+                                    "direction": "ltr",
+                                    "value": ""
+                                },
+                                "zh": {
+                                    "direction": "ltr",
+                                    "value": ""
+                                }
+                            },
+                            "0e90031e-4148-11e7-a176-c4b301baab9f": {
+                                "de": {
+                                    "direction": "ltr",
+                                    "value": ""
+                                },
+                                "el": {
+                                    "direction": "ltr",
+                                    "value": ""
+                                },
+                                "en": {
+                                    "direction": "ltr",
+                                    "value": "mapbox://fonts/mapbox/{fontstack}/{range}.pbf"
+                                },
+                                "en-US": {
+                                    "direction": "ltr",
+                                    "value": ""
+                                },
+                                "fr": {
+                                    "direction": "ltr",
+                                    "value": ""
+                                },
+                                "pt": {
+                                    "direction": "ltr",
+                                    "value": ""
+                                },
+                                "ru": {
+                                    "direction": "ltr",
+                                    "value": ""
+                                },
+                                "zh": {
+                                    "direction": "ltr",
+                                    "value": ""
+                                }
+                            }
+                        },
+                        "nodegroup_id": "0e8fe457-4148-11e7-9c10-c4b301baab9f",
+                        "parenttile_id": "3442b7e7-9bee-4c54-8d37-eca3a236ef8f",
+                        "provisionaledits": null,
+                        "resourceinstance_id": "a106c400-260c-11e7-a604-14109fd34195",
+                        "sortorder": 0,
+                        "tileid": "f49e37b3-3686-4fbd-98c9-ab8241f72a60"
                     }
-                ],
-                "resourceinstance": {
-                    "graph_id": "ff623370-fa12-11e6-b98b-6c4008b05c4c",
-                    "resourceinstanceid": "a106c400-260c-11e7-a604-14109fd34195",
-                    "legacyid": "a106c400-260c-11e7-a604-14109fd34195"
-                }
+                ]
             }
         ]
     }


### PR DESCRIPTION
This updates this package's System_Settings.json with the most recent V7 system settings.

Currently this package has the version 6 System_Settings.json that doesn't include i18n fields. Therefore, importing the package will render the settings page unusable with the following error:

![image](https://github.com/archesproject/arches-example-pkg/assets/119508494/f019e38f-a0cb-4a55-a0f9-61cd5526752a)

